### PR TITLE
Check if node exists

### DIFF
--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -46,7 +46,7 @@ def get_child_nodes(node):
     if isinstance(node, ast.Module):
         return node.body
     result = []
-    if node._fields is not None:
+    if node and node._fields is not None:
         for name in node._fields:
             child = getattr(node, name)
             if isinstance(child, list):


### PR DESCRIPTION
I think this happens when:

Operation: rename c -> z

from a.b import c 

```
def foo():
       from a.b import z
       z.foo()
```

https://github.com/python-rope/rope/blob/65080c52d5e1d6c196417b7c877af89ff44f5278/rope/base/evaluate.py#L289-L291

<rope.base.pyscopes.FunctionScope object at 0x127f77438> None

https://github.com/python-rope/rope/pull/325